### PR TITLE
Clarify how to run our examples and built-in Beam example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-words.txt
-wordcounts*
-*.gpkg
+/data/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,40 @@ Repo currently focuses on following along with the beam "getting started"
 materials: https://beam.apache.org/get-started/
 
 
+## System check
+
+To start, run the built-in copy of the word-count example with the following command,
+just to make sure that Apache Beam is correctly installed.
+
+```bash
+python -m apache_beam.examples.wordcount_minimal \
+  --input data/words.txt \
+  --output data/wordcounts_official_example.txt
+```
+
+This outputs a file `wordcounts_official_example.txt-00000-of-00001`. Why doesn't it
+match the requested output file name?
+
+
+## Our own implementaiton of the example
+
+```bash
+python -m wordcount_example \
+  --input data/words.txt \
+  --output data/wordcounts_our_example.txt
+```
+
+The output file looks the same as the output file from the above example. There is
+significantly less log output, however. Why is that?
+
+
+## Seal tag data spike
+
+```bash
+python -m seal_csv_to_gpkg
+```
+
+
 ## Useful resources
 
 * [Basics of the Beam model](https://beam.apache.org/documentation/basics/)

--- a/data/words.txt
+++ b/data/words.txt
@@ -1,0 +1,1 @@
+Foo Foo Foo Foo Foo bar dar bar foo Foo

--- a/seal_csv_to_gpkg.py
+++ b/seal_csv_to_gpkg.py
@@ -6,7 +6,7 @@ import apache_beam as beam
 
 
 INPUT_URL = "https://arcticdata.io/metacat/d1/mn/v2/object/urn%3Auuid%3A31162eb9-7e3b-4b88-948f-f4c99f13a83f"
-OUTPUT_PATH = "foo.gpkg"
+OUTPUT_PATH = "data/foo.gpkg"
 
 # This object lets us set various options for our pipeline, such as the pipeline
 # runner that will execute our pipeline and any runner-specific configuration

--- a/seal_csv_to_gpkg.sh
+++ b/seal_csv_to_gpkg.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-python -m seal_csv_to_gpkg

--- a/seal_csv_to_gpkg.sh
+++ b/seal_csv_to_gpkg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python -m seal_csv_to_gpkg

--- a/wordcount_example.py
+++ b/wordcount_example.py
@@ -12,10 +12,19 @@ import apache_beam as beam
 input_file = 'words.txt'
 output_path = 'wordcounts.txt'
 
+
+class WordCountOptions(PipelineOptions):
+    """Accept runtime Pipeline options."""
+    @classmethod
+    def _add_argparse_args(cls, parser):
+        parser.add_argument('--input', dest='input', help='File to read in')
+        parser.add_argument('--output', dest='output', help='File to write out')
+
+
 # This object lets us set various options for our pipeline, such as the pipeline
 # runner that will execute our pipeline and any runner-specific configuration
 # required by the chosen runner.
-beam_options = PipelineOptions(
+pipeline_options = WordCountOptions(
     runner='DirectRunner',
     project='wordcount',
     job_name='unique_wordcount_job_name',
@@ -26,8 +35,7 @@ beam_options = PipelineOptions(
 
 # The Pipeline object builds up the graph of transformations to be executed,
 # associated with that particular pipeline.
-with beam.Pipeline(options=beam_options) as p:
-
+with beam.Pipeline(options=pipeline_options) as p:
     (p
     # A text file Read transform is applied to the Pipeline object itself, and
     # produces a PCollection as output. Each element in the output PCollection

--- a/wordcount_example.py
+++ b/wordcount_example.py
@@ -9,8 +9,10 @@ import apache_beam as beam
 
 
 
-input_file = 'words.txt'
-output_path = 'wordcounts.txt'
+output_dir = 'data'
+# TODO: Will Beam accept pathlib.Paths?
+input_file = f'{output_dir}/words.txt'
+output_path = f'{output_dir}/wordcounts.txt'
 
 
 class WordCountOptions(PipelineOptions):

--- a/wordcount_example.sh
+++ b/wordcount_example.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python -m apache_beam.examples.wordcount_minimal --input words.txt --output wordcounts.txt
+python -m wordcount_example --input data/words.txt --output data/wordcounts.txt

--- a/wordcount_example.sh
+++ b/wordcount_example.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-python -m wordcount_example --input data/words.txt --output data/wordcounts.txt


### PR DESCRIPTION
We were running a pre-packaged example. 

Our `wordcount_example.py` driver program needs some adjustment. We currently write out `wordcounts.txt-00000-of-00001` instead of `wordcounts.txt` as expected.